### PR TITLE
Remove hardcoded start frame

### DIFF
--- a/src/caffe/layers/video_data_layer.cpp
+++ b/src/caffe/layers/video_data_layer.cpp
@@ -342,7 +342,7 @@ void VideoDataLayer<Dtype>::SetUp(const vector<Blob<Dtype>*>& bottom,
   }
   else{
 	  LOG(INFO) << "read video from " << file_list_[id].c_str();
-	  CHECK(ReadImageSequenceToVolumeDatum(file_list_[id].c_str(), 1, label_list_[id],
+	  CHECK(ReadImageSequenceToVolumeDatum(file_list_[id].c_str(), start_frm_list_[id], label_list_[id],
 	                             new_length, new_height, new_width, sampling_rate, &datum));
   }
 


### PR DESCRIPTION
`start_frm` was hardcoded as a 1 in a `CHECK` for `ReadImageSequenceToVolumeDatum`. Causes the `CHECK` to raise in error when starting from frame 0 and using exactly `new_length` frames.

:hattip: to @kjhawekotte for building and testing