### PR TITLE
adding "stream" mode to VideoDataLayer

### DIFF
--- a/examples/c3d_feature_extraction/c3d_sport1m_feature_extraction_video_stream.sh
+++ b/examples/c3d_feature_extraction/c3d_sport1m_feature_extraction_video_stream.sh
@@ -1,0 +1,4 @@
+mkdir -p output/c3d/v_ApplyEyeMakeup_g01_c01
+mkdir -p output/c3d/v_BaseballPitch_g01_c01
+mkdir -p output/c3d/CAMERA
+GLOG_logtosterr=1 ../../build/tools/extract_image_features.bin prototxt/c3d_sport1m_feature_extractor_video_stream.prototxt conv3d_deepnetA_sport1m_iter_1900000 0 50 -1 prototxt/output_list_video_stream_prefix.txt fc7-1 fc6-1 prob

--- a/examples/c3d_feature_extraction/prototxt/c3d_sport1m_feature_extractor_video_stream.prototxt
+++ b/examples/c3d_feature_extraction/prototxt/c3d_sport1m_feature_extractor_video_stream.prototxt
@@ -1,0 +1,450 @@
+name: "DeepConv3DNet_Sport1M_Val"
+layers {
+  name: "data"
+  type: VIDEO_DATA
+  top: "data"
+  top: "label"
+  image_data_param {
+    source: "prototxt/input_list_video_stream.txt"
+    use_image: false
+    use_stream: true
+    mean_file: "sport1m_train16_128_mean.binaryproto"
+    batch_size: 50
+    crop_size: 112
+    mirror: false
+    show_data: 0
+    new_height: 128
+    new_width: 171
+    new_length: 16
+    shuffle: false
+  }
+}
+# ----------- 1st layer group ---------------
+layers {
+  name: "conv1a"
+  type: CONVOLUTION3D
+  bottom: "data"
+  top: "conv1a"
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    kernel_size: 3
+    kernel_depth: 3
+    pad: 1
+    temporal_pad: 1
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layers {
+  name: "relu1a"
+  type: RELU
+  bottom: "conv1a"
+  top: "conv1a"
+}
+layers {
+  name: "pool1"
+  type: POOLING3D
+  bottom: "conv1a"
+  top: "pool1"
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    kernel_depth: 1
+    stride: 2
+    temporal_stride: 1
+  }
+}
+# ------------- 2nd layer group --------------
+layers {
+  name: "conv2a"
+  type: CONVOLUTION3D
+  bottom: "pool1"
+  top: "conv2a"
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 3
+    kernel_depth: 3
+    pad: 1
+    temporal_pad: 1
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 1
+    }
+  }
+}
+layers {
+  name: "relu2a"
+  type: RELU
+  bottom: "conv2a"
+  top: "conv2a"
+}
+layers {
+  name: "pool2"
+  type: POOLING3D
+  bottom: "conv2a"
+  top: "pool2"
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    kernel_depth: 2
+    stride: 2
+    temporal_stride: 2
+  }
+}
+# ----------------- 3rd layer group --------------
+layers {
+  name: "conv3a"
+  type: CONVOLUTION3D
+  bottom: "pool2"
+  top: "conv3a"
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 256
+    kernel_size: 3
+    kernel_depth: 3
+    pad: 1
+    temporal_pad: 1
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 1
+    }
+  }
+}
+layers {
+  name: "relu3a"
+  type: RELU
+  bottom: "conv3a"
+  top: "conv3a"
+}
+layers {
+  name: "conv3b"
+  type: CONVOLUTION3D
+  bottom: "conv3a"
+  top: "conv3b"
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 256
+    kernel_size: 3
+    kernel_depth: 3
+    pad: 1
+    temporal_pad: 1
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 1
+    }
+  }
+}
+layers {
+  name: "relu3b"
+  type: RELU
+  bottom: "conv3b"
+  top: "conv3b"
+}
+layers {
+  name: "pool3"
+  type: POOLING3D
+  bottom: "conv3b"
+  top: "pool3"
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    kernel_depth: 2
+    stride: 2
+    temporal_stride: 2
+  }
+}
+
+# --------- 4th layer group
+layers {
+  name: "conv4a"
+  type: CONVOLUTION3D
+  bottom: "pool3"
+  top: "conv4a"
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 512
+    kernel_size: 3
+    kernel_depth: 3
+    pad: 1
+    temporal_pad: 1
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 1
+    }
+  }
+}
+layers {
+  name: "relu4a"
+  type: RELU
+  bottom: "conv4a"
+  top: "conv4a"
+}
+layers {
+  name: "conv4b"
+  type: CONVOLUTION3D
+  bottom: "conv4a"
+  top: "conv4b"
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 512
+    kernel_size: 3
+    kernel_depth: 3
+    pad: 1
+    temporal_pad: 1
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 1
+    }
+  }
+}
+layers {
+  name: "relu4b"
+  type: RELU
+  bottom: "conv4b"
+  top: "conv4b"
+}
+layers {
+  name: "pool4"
+  type: POOLING3D
+  bottom: "conv4b"
+  top: "pool4"
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    kernel_depth: 2
+    stride: 2
+    temporal_stride: 2
+  }
+}
+
+# --------------- 5th layer group --------
+layers {
+  name: "conv5a"
+  type: CONVOLUTION3D
+  bottom: "pool4"
+  top: "conv5a"
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 512
+    kernel_size: 3
+    kernel_depth: 3
+    pad: 1
+    temporal_pad: 1
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 1
+    }
+  }
+}
+layers {
+  name: "relu5a"
+  type: RELU
+  bottom: "conv5a"
+  top: "conv5a"
+}
+layers {
+  name: "conv5b"
+  type: CONVOLUTION3D
+  bottom: "conv5a"
+  top: "conv5b"
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 512
+    kernel_size: 3
+    kernel_depth: 3
+    pad: 1
+    temporal_pad: 1
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 1
+    }
+  }
+}
+layers {
+  name: "relu5b"
+  type: RELU
+  bottom: "conv5b"
+  top: "conv5b"
+}
+
+layers {
+  name: "pool5"
+  type: POOLING3D
+  bottom: "conv5b"
+  top: "pool5"
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    kernel_depth: 2
+    stride: 2
+    temporal_stride: 2
+  }
+}
+# ---------------- fc layers -------------
+layers {
+  name: "fc6-1"
+  type: INNER_PRODUCT
+  bottom: "pool5"
+  top: "fc6-1"
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  inner_product_param {
+    num_output: 4096
+    weight_filler {
+      type: "gaussian"
+      std: 0.005
+    }
+    bias_filler {
+      type: "constant"
+      value: 1
+    }
+  }
+}
+layers {
+  name: "relu6"
+  type: RELU
+  bottom: "fc6-1"
+  top: "fc6-1"
+}
+layers {
+  name: "drop6"
+  type: DROPOUT
+  bottom: "fc6-1"
+  top: "fc6-1"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+layers {
+  name: "fc7-1"
+  type: INNER_PRODUCT
+  bottom: "fc6-1"
+  top: "fc7-1"
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  inner_product_param {
+    num_output: 4096
+    weight_filler {
+    type: "gaussian"
+      std: 0.005
+    }
+    bias_filler {
+      type: "constant"
+      value: 1
+    }
+  }
+}
+layers {
+  name: "relu7"
+  type: RELU
+  bottom: "fc7-1"
+  top: "fc7-1"
+}
+layers {
+  name: "drop7"
+  type: DROPOUT
+  bottom: "fc7-1"
+  top: "fc7-1"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+layers {
+  name: "fc8-1"
+  type: INNER_PRODUCT
+  bottom: "fc7-1"
+  top: "fc8-1"
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  inner_product_param {
+    num_output: 487
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layers {
+  name: "prob"
+  type: SOFTMAX
+  bottom: "fc8-1"
+  top: "prob"
+}
+layers {
+  name: "accuracy"
+  type: ACCURACY
+  bottom: "prob"
+  bottom: "label"
+  top: "accuracy"
+  #top: "prediction_truth"
+}

--- a/examples/c3d_feature_extraction/prototxt/input_list_video_stream.txt
+++ b/examples/c3d_feature_extraction/prototxt/input_list_video_stream.txt
@@ -1,0 +1,3 @@
+input/avi/v_ApplyEyeMakeup_g01_c01.avi 0 16 0
+input/avi/v_BaseballPitch_g01_c01.avi 0 16 0
+CAMERA 0 16 0

--- a/examples/c3d_feature_extraction/prototxt/output_list_video_stream_prefix.txt
+++ b/examples/c3d_feature_extraction/prototxt/output_list_video_stream_prefix.txt
@@ -1,0 +1,1 @@
+output/c3d/

--- a/include/caffe/util/image_io.hpp
+++ b/include/caffe/util/image_io.hpp
@@ -59,6 +59,9 @@ inline bool ReadImageSequenceToVolumeDatum(const char* img_dir, const int start_
 	return ReadImageSequenceToVolumeDatum(img_dir, start_frm, label, length, 0, 0, sampling_rate, datum);
 }
 
+bool ReadImageVectorToVolumeDatum(const std::vector<cv::Mat>& imgs, const int label,
+        const int length, const int height, const int width, VolumeDatum* datum);
+
 template <typename Dtype>
 bool load_blob_from_binary(const string fn_blob, Blob<Dtype>* blob);
 

--- a/include/caffe/video_data_layer.hpp
+++ b/include/caffe/video_data_layer.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <deque>
 
 #include "pthread.h"
 #include "boost/scoped_ptr.hpp"
@@ -49,6 +50,9 @@ class VideoDataLayer : public Layer<Dtype> {
   virtual void SetUp(const vector<Blob<Dtype>*>& bottom,
       vector<Blob<Dtype>*>* top);
 
+  vector<string> pop_stream_names(int num);
+  bool is_stream_done() { return is_stream_done_; }
+
  protected:
   virtual Dtype Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       vector<Blob<Dtype>*>* top);
@@ -66,9 +70,14 @@ class VideoDataLayer : public Layer<Dtype> {
   shared_ptr<Caffe::RNG> prefetch_rng_;
   vector<string> file_list_;
   vector<int> start_frm_list_;
+  vector<int> num_of_frames_list_;
+  vector<int> interval_list_;
   vector<int> label_list_;
   vector<int> shuffle_index_;
   int lines_id_;
+  int interval_jump_;
+  std::deque<string> stream_names_;
+  bool is_stream_done_;
 
   int datum_channels_;
   int datum_length_;

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -324,6 +324,7 @@ message ImageDataParameter {
   optional uint32 new_length = 11 [default = 0];
   optional int32 show_data = 12 [default = 0];
   optional bool use_image = 13 [default = false];
+  optional bool use_stream = 113 [default = false];
   optional int32 sampling_rate = 14 [default = 1];
   optional bool use_label = 15 [default = true];
   optional bool use_temporal_jitter = 16 [default = false];

--- a/tools/extract_image_features.cpp
+++ b/tools/extract_image_features.cpp
@@ -26,6 +26,7 @@
 #include "caffe/common.hpp"
 #include "caffe/net.hpp"
 #include "caffe/vision_layers.hpp"
+#include "caffe/video_data_layer.hpp"
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/util/io.hpp"
 #include "caffe/util/image_io.hpp"
@@ -45,18 +46,18 @@ int feature_extraction_pipeline(int argc, char** argv) {
   char* pretrained_model = argv[2];
   int device_id = atoi(argv[3]);
   uint batch_size = atoi(argv[4]);
-  uint num_mini_batches = atoi(argv[5]);
+  int num_mini_batches = atoi(argv[5]);
   char* fn_feat = argv[6];
 
   Caffe::set_phase(Caffe::TEST);
   if (device_id>=0){
-	  Caffe::set_mode(Caffe::GPU);
-	  Caffe::SetDevice(device_id);
-	  LOG(ERROR) << "Using GPU #" << device_id;
+    Caffe::set_mode(Caffe::GPU);
+    Caffe::SetDevice(device_id);
+    LOG(ERROR) << "Using GPU #" << device_id;
   }
   else{
-	  Caffe::set_mode(Caffe::CPU);
-	  LOG(ERROR) << "Using CPU";
+    Caffe::set_mode(Caffe::CPU);
+    LOG(ERROR) << "Using CPU";
   }
 
   shared_ptr<Net<Dtype> > feature_extraction_net(
@@ -67,6 +68,51 @@ int feature_extraction_pipeline(int argc, char** argv) {
   CHECK(feature_extraction_net->has_blob(string(argv[i])))
       << "Unknown feature blob name " << string(argv[i])
       << " in the network " << string(net_proto);
+  }
+
+  if (num_mini_batches < 0)
+  {
+    LOG(ERROR)<< "Extracting features until program is terminated";
+    std::ifstream infile(fn_feat);
+    string feat_prefix;
+    std::vector<string> list_prefix;
+    int c = 0;
+    infile >> feat_prefix;
+
+    vector<Blob<float>*> input_vec;
+    int image_index = 0;
+
+    boost::shared_ptr<caffe::Layer<float> > data_layer;
+    boost::shared_ptr< VideoDataLayer<Dtype> > video_data_layer;
+    data_layer = feature_extraction_net->layers()[0];
+    video_data_layer = boost::dynamic_pointer_cast< VideoDataLayer<Dtype> >(data_layer);
+    if (!video_data_layer) {
+      LOG(ERROR)<< "This mode may only be used if the first layer is a VideoDataLayer";
+    }
+
+    while (1) {
+      feature_extraction_net->Forward(input_vec);
+      list_prefix = video_data_layer->pop_stream_names(batch_size);
+
+      if (list_prefix.empty())
+        break;
+      for (int k=7; k<argc; k++){
+        const shared_ptr<Blob<Dtype> > feature_blob = feature_extraction_net
+          ->blob_by_name(string(argv[k]));
+        int num_features = feature_blob->num();
+
+        Dtype* feature_blob_data;
+        for (int n = 0; n < num_features; ++n) {
+          if (list_prefix.size()>n){
+            string fn_feat = feat_prefix + list_prefix[n] + string(".") + string(argv[k]);
+            save_blob_to_binary(feature_blob.get(), fn_feat, n);
+          }
+        }
+      }
+      image_index += list_prefix.size();
+    }
+    LOG(ERROR)<< "Successfully extracted " << image_index << " features!";
+    return 0;
   }
 
   LOG(ERROR)<< "Extracting features for " << num_mini_batches << " batches";
@@ -82,26 +128,26 @@ int feature_extraction_pipeline(int argc, char** argv) {
     feature_extraction_net->Forward(input_vec);
     list_prefix.clear();
     for (int n=0; n<batch_size; n++){
-    	if (infile >> feat_prefix)
-    		list_prefix.push_back(feat_prefix);
-    	else
-    		break;
+      if (infile >> feat_prefix)
+        list_prefix.push_back(feat_prefix);
+      else
+        break;
     }
 
     if (list_prefix.empty())
-    	break;
+      break;
     for (int k=7; k<argc; k++){
-    	const shared_ptr<Blob<Dtype> > feature_blob = feature_extraction_net
+      const shared_ptr<Blob<Dtype> > feature_blob = feature_extraction_net
         ->blob_by_name(string(argv[k]));
-    	int num_features = feature_blob->num();
+      int num_features = feature_blob->num();
 
-    	Dtype* feature_blob_data;
-        for (int n = 0; n < num_features; ++n) {
-          if (list_prefix.size()>n){
-        	  string fn_feat = list_prefix[n] + string(".") + string(argv[k]);
-        	  save_blob_to_binary(feature_blob.get(), fn_feat, n);
-          }
+      Dtype* feature_blob_data;
+      for (int n = 0; n < num_features; ++n) {
+        if (list_prefix.size()>n){
+          string fn_feat = list_prefix[n] + string(".") + string(argv[k]);
+          save_blob_to_binary(feature_blob.get(), fn_feat, n);
         }
+      }
     }
     image_index += list_prefix.size();
     if (batch_index % 100 == 0) {


### PR DESCRIPTION
The "stream" mode lets the users extract features from videos without having to specify the frame numbers in the input or output text files. It can also load from live camera. The original behaviour to load videos is kept intact, and also any modifications are welcome.

How to use:

1. Set the new flag 'use_stream' to true in the video data layer in the prototxt file.
2. Change "extract_image_features.bin" argument 'num_mini_batches' to a negative number. (to indicate an infinite number)
3. Change the input text file format
   ex) `input/avi/v_ApplyEyeMakeup_g01_c01.avi 0 16 0`
   [filename] [start_frm] [interval] [label]
   You can put 'CAMERA' in [filename] to load from the live camera.
4. Change the output text file format
   ex) `output/c3d/`
   In the stream mode, the output location is automatically determined from the input.
   [output_location][input_filename][start_frm].txt

- I provided an example script "c3d_sport1m_feature_extraction_video**_stream**.sh" to demonstrate the stream mode