### PR TITLE
Update hdf5_data_layer.cpp

### DIFF
--- a/src/caffe/layers/hdf5_data_layer.cpp
+++ b/src/caffe/layers/hdf5_data_layer.cpp
@@ -79,7 +79,7 @@ void HDF5DataLayer<Dtype>::SetUp(const vector<Blob<Dtype>*>& bottom,
   const int batch_size = this->layer_param_.hdf5_data_param().batch_size();
   (*top)[0]->Reshape(batch_size, data_blob_.channels(), data_blob_.length(),
                      data_blob_.width(), data_blob_.height());
-  (*top)[1]->Reshape(batch_size, label_blob_.channels(), data_blob_.length(),
+  (*top)[1]->Reshape(batch_size, label_blob_.channels(), label_blob_.length(),
                      label_blob_.width(), label_blob_.height());
   LOG(INFO) << "output data size: " << (*top)[0]->num() << ","
       << (*top)[0]->channels() << "," << (*top)[0]->length() << ","


### PR DESCRIPTION
Line#82. Label blob mistakenly reshaped to data_blob.length corrected.