### PR TITLE
Possible overflowing integer numbers in image_io.cpp

### DIFF
--- a/src/caffe/util/image_io.cpp
+++ b/src/caffe/util/image_io.cpp
@@ -177,7 +177,7 @@ bool ReadImageSequenceToVolumeDatum(const char* img_dir, const int start_frm, co
 	char fn_im[256];
 	cv::Mat img, img_origin;
 	char *buffer;
-	int offset, channel_size, image_size, data_size;
+	unsigned long int offset, channel_size, image_size, data_size;
 
 	datum->set_channels(3);
 	datum->set_length(length);

--- a/src/caffe/util/image_io.cpp
+++ b/src/caffe/util/image_io.cpp
@@ -103,7 +103,7 @@ bool ReadVideoToVolumeDatum(const char* filename, const int start_frm, const int
 	cv::VideoCapture cap;
 	cv::Mat img, img_origin;
 	char *buffer;
-	int offset, channel_size, image_size, data_size;
+	unsigned long int offset, channel_size, image_size, data_size;
 	int use_start_frm = start_frm;
 
 	cap.open(filename);


### PR DESCRIPTION
This PR is following up the discussion in issue #162. 
I have not encounter this problem. Just a hypothesis. I met another problem, then I thought there are a overflowing integer number because of integral multiplication operations in function `ReadImageSequenceToVolumeDatum`. In [line 180](https://github.com/facebook/C3D/blob/master/src/caffe/util/image_io.cpp#L180), all variables are `int`, but all multiplication operations in [line 210-212](https://github.com/facebook/C3D/blob/master/src/caffe/util/image_io.cpp#L210-212) seems to be larger than integer numbers. I do not know exactly how compiler and system handle these numbers. There might be overflowing numbers in theoretical sense. For example, if the volume size `(3, 16, 128, 171)`, then:
`image_size=128*171=21888, channel_size=16*128*171=350208, data_size=3*16*128*171=1050624`. 
These numbers are larger than traditional maximum defined values of an `int`. However, in practice, I use the code without any problems with this function to read the images into video volume.
With recent techniques with [longer temporal convolution](https://arxiv.org/abs/1604.04494), it seems that we need a larger variable to hold these values.