### PR TITLE
fix compile warnings and update mkdir and wget

### DIFF
--- a/C3D-v1.1/examples/c3d_ucf101_feature_extraction/feature_extraction.sh
+++ b/C3D-v1.1/examples/c3d_ucf101_feature_extraction/feature_extraction.sh
@@ -1,3 +1,5 @@
-wget https://www.dropbox.com/s/qqfrg6h44d4jb46/c3d_resnet18_sports1m_r2_iter_2800000.caffemodel
+if [ ! -f c3d_resnet18_sports1m_r2_iter_2800000.caffemodel ];then
+	wget https://www.dropbox.com/s/qqfrg6h44d4jb46/c3d_resnet18_sports1m_r2_iter_2800000.caffemodel
+fi
 
 GLOG_logtostderr=1 ../../build/tools/extract_image_features.bin c3d_resnet18_ucf101_feature_extraction.prototxt c3d_resnet18_sports1m_r2_iter_2800000.caffemodel 0 30 4970 ucf101_video_frame.prefix prob pool5 res5b

--- a/C3D-v1.1/examples/c3d_ucf101_finetuning/finetuning_ucf101.sh
+++ b/C3D-v1.1/examples/c3d_ucf101_finetuning/finetuning_ucf101.sh
@@ -1,4 +1,6 @@
-wget https://www.dropbox.com/s/qqfrg6h44d4jb46/c3d_resnet18_sports1m_r2_iter_2800000.caffemodel
+if [ ! -f c3d_resnet18_sports1m_r2_iter_2800000.caffemodel ]; then
+	wget https://www.dropbox.com/s/qqfrg6h44d4jb46/c3d_resnet18_sports1m_r2_iter_2800000.caffemodel
+fi
 
 mkdir -p LOG_TRAIN
 

--- a/C3D-v1.1/examples/c3d_ucf101_finetuning/finetuning_ucf101.sh
+++ b/C3D-v1.1/examples/c3d_ucf101_finetuning/finetuning_ucf101.sh
@@ -1,5 +1,5 @@
 wget https://www.dropbox.com/s/qqfrg6h44d4jb46/c3d_resnet18_sports1m_r2_iter_2800000.caffemodel
 
-mkdir LOG_TRAIN
+mkdir -p LOG_TRAIN
 
 GLOG_log_dir="./LOG_TRAIN" ../../build/tools/caffe.bin train --solver=solver_r2.prototxt --weights=c3d_resnet18_sports1m_r2_iter_2800000.caffemodel --gpu=0

--- a/C3D-v1.1/examples/c3d_ucf101_training/train_simple.sh
+++ b/C3D-v1.1/examples/c3d_ucf101_training/train_simple.sh
@@ -1,2 +1,2 @@
-mkdir LOG_TRAIN
+mkdir -p LOG_TRAIN
 GLOG_log_dir="./LOG_TRAIN/" ../../build/tools/caffe.bin train --solver=solver.prototxt --gpu=0

--- a/C3D-v1.1/src/caffe/layers/deconvolution3d_layer.cpp
+++ b/C3D-v1.1/src/caffe/layers/deconvolution3d_layer.cpp
@@ -163,8 +163,6 @@ void Deconvolution3DLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom
   Dtype* col_data = col_buffer_.mutable_cpu_data();
   const Dtype* weight = this->blobs_[0]->cpu_data();
 
-  int weight_offset = M_ * K_;
-  int top_offset = M_ * N_;
   static const int zero_array[] = {0, 0, 0, 0, 0};
   vector<int> offset_indices(zero_array, zero_array + 5);
 
@@ -202,7 +200,6 @@ void Deconvolution3DLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
   Dtype* weight_diff = this->blobs_[0]->mutable_cpu_diff();
   const Dtype* bottom_data = bottom[0]->cpu_data();
   Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
-  Dtype* col_data = col_buffer_.mutable_cpu_data();
   Dtype* col_diff = col_buffer_.mutable_cpu_diff();
   // bias gradient if necessary
   Dtype* bias_diff = NULL;

--- a/C3D-v1.1/src/caffe/util/image_io.cpp
+++ b/C3D-v1.1/src/caffe/util/image_io.cpp
@@ -135,7 +135,10 @@ bool ReadVideoToVolumeDatumHelper(const char* filename, const int start_frm,
   cv::VideoCapture cap;
   cv::Mat img, img_origin;
   char *buffer = NULL;
-  int offset, channel_size, image_size, data_size;
+  int offset = 0;
+  int channel_size = 0;
+  int image_size = 0;
+  int data_size = 0;
   int use_start_frm = start_frm;
 
   cap.open(filename);
@@ -219,8 +222,11 @@ bool ReadVideoToVolumeDatumHelperSafe(const char* filename, const int start_frm,
   const int sampling_rate, VolumeDatum* datum){
   cv::VideoCapture cap;
 	cv::Mat img, img_origin;
-  char *buffer = NULL;
-	int offset, channel_size, image_size, data_size;
+  	char *buffer = NULL;
+	int offset = 0;
+	int channel_size = 0;
+	int image_size = 0;
+	int data_size = 0;
 	int use_start_frm = start_frm;
 
 	cap.open(filename);
@@ -311,8 +317,11 @@ bool ReadImageSequenceToVolumeDatum(const char* img_dir, const int start_frm, co
 		const int length, const int height, const int width, const int sampling_rate, VolumeDatum* datum){
 	char fn_im[256];
 	cv::Mat img, img_origin;
-	char *buffer;
-	int offset, channel_size, image_size, data_size;
+	char *buffer = NULL;
+	int offset = 0;
+	int channel_size = 0;
+	int image_size = 0;
+	int data_size = 0;
 
 	datum->set_channels(3);
 	datum->set_length(length);


### PR DESCRIPTION
Hi @dutran, 
In this PR, i do these things:
 1. remove used variables to suppress warnings when make
 2. initialize some variables to suppress warnings when make
 3. add `-p` option to `mkdir` to avoid error when run the scripts again
 4. check if file exists before run `wget` since it's time-consuming and unhelpful to download a very large model if it already exists.

Please check it and I hope to hear from you.